### PR TITLE
Add support to install a specific version of plugin

### DIFF
--- a/client/pluginManager_test.go
+++ b/client/pluginManager_test.go
@@ -38,16 +38,16 @@ var _ = Describe("PluginManager test", func() {
 	Context("basic function test", func() {
 		It("get install plugin query string", func() {
 			names := make([]string, 0)
-			Expect(getPluginsInstallQuery(names)).To(Equal(""))
+			Expect(pluginMgr.getPluginsInstallQuery(names)).To(Equal(""))
 
 			names = append(names, "abc")
-			Expect(getPluginsInstallQuery(names)).To(Equal("plugin.abc="))
+			Expect(pluginMgr.getPluginsInstallQuery(names)).To(Equal("plugin.abc="))
 
 			names = append(names, "def")
-			Expect(getPluginsInstallQuery(names)).To(Equal("plugin.abc=&plugin.def="))
+			Expect(pluginMgr.getPluginsInstallQuery(names)).To(Equal("plugin.abc=&plugin.def="))
 
 			names = append(names, "")
-			Expect(getPluginsInstallQuery(names)).To(Equal("plugin.abc=&plugin.def="))
+			Expect(pluginMgr.getPluginsInstallQuery(names)).To(Equal("plugin.abc=&plugin.def="))
 		})
 	})
 
@@ -141,10 +141,24 @@ var _ = Describe("PluginManager test", func() {
 			Expect(err).To(BeNil())
 		})
 
+		It("normal case with version, should success", func() {
+			PrepareForInstallPluginWithVersion(roundTripper, pluginMgr.URL, pluginName, "1.0", "", "")
+
+			err := pluginMgr.InstallPlugin([]string{pluginName + "@" + "1.0"})
+			Expect(err).To(BeNil())
+		})
+
 		It("with 400", func() {
 			PrepareForInstallPluginWithCode(roundTripper, 400, pluginMgr.URL, pluginName, "", "")
 
 			err := pluginMgr.InstallPlugin([]string{pluginName})
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("with 400 & version", func() {
+			PrepareForInstallPluginWithCode(roundTripper, 400, pluginMgr.URL, pluginName + "@" + "1.0", "", "")
+
+			err := pluginMgr.InstallPlugin([]string{pluginName + "@" + "1.0"})
 			Expect(err).NotTo(BeNil())
 		})
 

--- a/client/test_methods.go
+++ b/client/test_methods.go
@@ -407,6 +407,11 @@ func PrepareForInstallPlugin(roundTripper *mhttp.MockRoundTripper, rootURL, plug
 	PrepareForInstallPluginWithCode(roundTripper, 200, rootURL, pluginName, user, passwd)
 }
 
+// PrepareForInstallPluginWithVersion only for test
+func PrepareForInstallPluginWithVersion(roundTripper *mhttp.MockRoundTripper, rootURL, pluginName, version, user, passwd string)  {
+	PrepareForInstallPluginWithCode(roundTripper, 200, rootURL, pluginName + "@" + version, user, passwd)
+}
+
 // PrepareForInstallPluginWithCode only for test
 func PrepareForInstallPluginWithCode(roundTripper *mhttp.MockRoundTripper,
 	statusCode int, rootURL, pluginName, user, passwd string) (response *http.Response) {


### PR DESCRIPTION
Added as an option to `install` command

```
jcli plugin install localization-zh-cn jacoco@2.0.1
```
This will install `latest version of localization-zh-cn` & `version 2.0.1 of jacoco plugin`.