### PR TITLE
Add man page support

### DIFF
--- a/app/cmd/doc.go
+++ b/app/cmd/doc.go
@@ -51,11 +51,12 @@ version: %s
 )
 
 var docCmd = &cobra.Command{
-	Use:     "doc",
-	Example: "doc tmp",
-	Short:   i18n.T("Generate document for all jcl commands"),
-	Long:    i18n.T("Generate document for all jcl commands"),
-	Args:    cobra.MinimumNArgs(1),
+	Use: "doc",
+	Example: `jcli doc tmp
+jcli doc --doc-type ManPage /usr/local/share/man/man1`,
+	Short: i18n.T("Generate document for all jcl commands"),
+	Long:  i18n.T("Generate document for all jcl commands"),
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		outputDir := args[0]
 		if err = os.MkdirAll(outputDir, os.FileMode(0755)); err != nil {

--- a/app/cmd/doc.go
+++ b/app/cmd/doc.go
@@ -19,8 +19,10 @@ type DocOption struct {
 }
 
 const (
+	// DocTypeMarkdown represents markdown type of doc
 	DocTypeMarkdown string = "Markdown"
-	DocTypeManPage  string = "ManPage"
+	// DocTypeManPage represents man page type of doc
+	DocTypeManPage string = "ManPage"
 )
 
 var docOption DocOption

--- a/app/cmd/doc.go
+++ b/app/cmd/doc.go
@@ -2,21 +2,41 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/jenkins-zh/jenkins-cli/app"
+	"github.com/jenkins-zh/jenkins-cli/app/i18n"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/jenkins-zh/jenkins-cli/app"
-
-	"github.com/jenkins-zh/jenkins-cli/app/i18n"
-	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 )
+
+// DocOption is the option for doc generating
+type DocOption struct {
+	DocType string
+}
+
+const (
+	DocTypeMarkdown string = "Markdown"
+	DocTypeManPage  string = "ManPage"
+)
+
+var docOption DocOption
 
 func init() {
 	rootCmd.AddCommand(docCmd)
+	docCmd.Flags().StringVarP(&docOption.DocType, "doc-type", "", DocTypeMarkdown,
+		"Which type of document will generate")
+
+	err := docCmd.RegisterFlagCompletionFunc("doc-type", func(cmd *cobra.Command, args []string, toComplete string) (
+		i []string, directive cobra.ShellCompDirective) {
+		return []string{DocTypeMarkdown, DocTypeManPage}, cobra.ShellCompDirectiveDefault
+	})
+	if err != nil {
+		docCmd.PrintErrf("register flag doc-type for sub-command doc failed %#v\n", err)
+	}
 }
 
 const (
@@ -35,24 +55,36 @@ var docCmd = &cobra.Command{
 	Long:    i18n.T("Generate document for all jcl commands"),
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		now := time.Now().Format(time.RFC3339)
-		prepender := func(filename string) string {
-			name := filepath.Base(filename)
-			base := strings.TrimSuffix(name, path.Ext(name))
-			return fmt.Sprintf(gendocFrontmatterTemplate, now,
-				strings.Replace(base, "_", " ", -1),
-				app.GetVersion())
-		}
-
-		linkHandler := func(name string) string {
-			base := strings.TrimSuffix(name, path.Ext(name))
-			return "/commands/" + strings.ToLower(base) + "/"
-		}
-
 		outputDir := args[0]
-		if err = os.MkdirAll(outputDir, os.FileMode(0755)); err == nil {
+		if err = os.MkdirAll(outputDir, os.FileMode(0755)); err != nil {
+			return
+		}
+
+		switch docOption.DocType {
+		case DocTypeMarkdown:
+			now := time.Now().Format(time.RFC3339)
+			prepender := func(filename string) string {
+				name := filepath.Base(filename)
+				base := strings.TrimSuffix(name, path.Ext(name))
+				return fmt.Sprintf(gendocFrontmatterTemplate, now,
+					strings.Replace(base, "_", " ", -1),
+					app.GetVersion())
+			}
+
+			linkHandler := func(name string) string {
+				base := strings.TrimSuffix(name, path.Ext(name))
+				return "/commands/" + strings.ToLower(base) + "/"
+			}
+
 			rootCmd.DisableAutoGenTag = true
 			err = doc.GenMarkdownTreeCustom(rootCmd, outputDir, prepender, linkHandler)
+		case DocTypeManPage:
+			header := &doc.GenManHeader{
+				Title:   "Jenkins CLI",
+				Section: "1",
+				Source:  "Jenkins Chinese Community",
+			}
+			err = doc.GenManTree(rootCmd, header, outputDir)
 		}
 		return
 	},


### PR DESCRIPTION
make sure install man page through brew automatically

learn how to do it from [here](https://github.com/Homebrew/homebrew-core/blob/0bfab81c6aa33b6f827ae5505ee96e36a37593dc/Formula/hugo.rb#L28)

**Make sure that you've checked the boxes below before you submit PR:**

### Always

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Written well with PR title, we generate the [release notes](https://github.com/jenkins-zh/jenkins-cli/releases) base on that

### For the bug fixes or features only

- [ ] [Quality Gate Passed](https://sonarcloud.io/dashboard?id=jenkins-zh_jenkins-cli). Change this URL to your PR.
- [ ] The coverage is xxx on the new lines
- [x] I've tested it by manual in the following platform
  - [x] MacOS
  - [x] Linux
  - [ ] Windows

<!--
Put an `x` into the [ ] to show you have filled the information
-->