### PR TITLE
Fix the unavailable GitHub release stats service

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -61,7 +61,7 @@ sudo mv jcli /usr/local/bin/
 
 * [Scoop](https://scoop.sh/) 的用户可以使用命令 `scoop install jcli` 来安装
 
-了解更多[如何下载 jcli](https://github.com/jenkins-zh/jenkins-cli/tree/e83af606f648040665b8b2955c1c2414bb68c1db/docs/book/zh/download-zh.md). 你可以从[这里](http://somsubhra.com/github-release-stats/?username=jenkins-zh&repository=jenkins-cli)获取下载的统计信息。
+了解更多[如何下载 jcli](https://github.com/jenkins-zh/jenkins-cli/tree/e83af606f648040665b8b2955c1c2414bb68c1db/docs/book/zh/download-zh.md). 你可以从[这里](https://tooomm.github.io/github-release-stats/?username=jenkins-zh&repository=jenkins-cli)获取下载的统计信息。
 
 ## 入门
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Here are other package managers:
 | `choco install jcli` | `choco upgrade jcli` | `choco uninstall jcli` | `Windows` |
 | `snap install jcli` | `snap refresh jcli` | `snap remove jcli` | `Linux` |
 
-See more about [how to download jcli](docs/book/en/download.md). You can find the download details [from here](http://somsubhra.com/github-release-stats/?username=jenkins-zh&repository=jenkins-cli).
+See more about [how to download jcli](docs/book/en/download.md). You can find the download details [from here](https://tooomm.github.io/github-release-stats/?username=jenkins-zh&repository=jenkins-cli).
 
 ## Get started
 


### PR DESCRIPTION
**Make sure that you've checked the boxes below before you submit PR:**

### Always

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Written well with PR title, we generate the [release notes](https://github.com/jenkins-zh/jenkins-cli/releases) base on that

### For the bug fixes or features only

- [ ] [Quality Gate Passed](https://sonarcloud.io/dashboard?id=jenkins-zh_jenkins-cli). Change this URL to your PR.
- [ ] The coverage is xxx on the new lines
- [ ] I've tested it by manual in the following platform
  - [ ] MacOS
  - [ ] Linux
  - [ ] Windows

<!--
Put an `x` into the [ ] to show you have filled the information
-->
