### PR TITLE
Revert "Fix segfaults URL param"

### DIFF
--- a/util/url.go
+++ b/util/url.go
@@ -17,7 +17,7 @@ func URLJoin(host, api string) (targetURL *url.URL, err error) {
 //URLJoinAsString  is a util function to join host URL and API URL
 func URLJoinAsString(host, api string) (targetURLStr string, err error) {
 	var targetURL *url.URL
-	if targetURL, err = URLJoin(host, url.QueryEscape(api)); err == nil {
+	if targetURL, err = URLJoin(host, api); err == nil {
 		targetURLStr = targetURL.String()
 	}
 	return


### PR DESCRIPTION
Reverts jenkins-zh/jenkins-cli#541
Because it caused some commands to fail. See the following error output with command `jcli plugin list --logger-level debug`:

`{"level":"debug","message":"send HTTP request","URL":"http://103.61.37.132:30180/%2FpluginManager%2Fapi%2Fjson%3Fdepth%3D1","method":"GET"}`