### PR TITLE
Bump go verion from 1.12 to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jenkins-zh/jenkins-cli
 
-go 1.12
+go 1.14
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.9


### PR DESCRIPTION
Parts of the dependencies rely on go 1.14

**Make sure that you've checked the boxes below before you submit PR:**

### Always

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Written well with PR title, we generate the [release notes](https://github.com/jenkins-zh/jenkins-cli/releases) base on that

### For the bug fixes or features only

- [ ] [Quality Gate Passed](https://sonarcloud.io/dashboard?id=jenkins-zh_jenkins-cli). Change this URL to your PR.
- [ ] The coverage is xxx on the new lines
- [x] I've tested it by manual in the following platform
  - [x] MacOS
  - [ ] Linux
  - [ ] Windows
- [ ] Unit Test covered
- [ ] e2e Test covered

<!--
Put an `x` into the [ ] to show you have filled the information
-->
